### PR TITLE
Atomic lock run execute

### DIFF
--- a/core/src/main/scala/io/paradoxical/aetr/core/config/ServiceConfig.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/config/ServiceConfig.scala
@@ -1,8 +1,11 @@
 package io.paradoxical.aetr.core.config
 
 import io.paradoxical.rdb.hikari.config.RdbConfigWithConnectionPool
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 case class ServiceConfig(
   maxAtomicRetries: Int = 10,
-  db: RdbConfigWithConnectionPool
+  db: RdbConfigWithConnectionPool,
+  dbLockTime: FiniteDuration = 60 seconds
 )

--- a/core/src/main/scala/io/paradoxical/aetr/core/db/Storage.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/db/Storage.scala
@@ -69,7 +69,7 @@ class Storage @Inject()(stepDb: StepDb) {
    * @param state
    * @return
    */
-  def findRuns(state: RunState): List[RootId] = {
-    stepDb.findRuns(state).waitForResult()
+  def findUnlockedRuns(state: RunState): List[RootId] = {
+    stepDb.findUnlockedRuns(state).waitForResult()
   }
 }

--- a/core/src/main/scala/io/paradoxical/aetr/core/db/dao/DataMappers.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/db/dao/DataMappers.scala
@@ -1,5 +1,6 @@
 package io.paradoxical.aetr.core.db.dao
 
+import io.paradoxical.aetr.core.db.dao.tables.LockId
 import io.paradoxical.aetr.core.model._
 import io.paradoxical.jackson.JacksonSerializer
 import io.paradoxical.rdb.slick.dao.SlickDAO
@@ -35,8 +36,12 @@ class DataMappers @Inject()(
     MappedColumnType.base[RunInstanceId, String](_.value.toString, s => RunInstanceId(UUID.fromString(s)))
   }
 
-  implicit val rootIdMapper: JdbcType[Root] with BaseTypedType[Root] = {
-    MappedColumnType.base[Root, String](_.value.toString, s => Root(UUID.fromString(s)))
+  implicit val lockIdMapper: JdbcType[LockId] with BaseTypedType[LockId] = {
+    MappedColumnType.base[LockId, String](_.value.toString, s => LockId(UUID.fromString(s)))
+  }
+
+  implicit val rootIdMapper: JdbcType[RootId] with BaseTypedType[RootId] = {
+    MappedColumnType.base[RootId, String](_.value.toString, s => RootId(UUID.fromString(s)))
   }
 
   implicit val resultDataMapper: JdbcType[ResultData] with BaseTypedType[ResultData] = {

--- a/core/src/main/scala/io/paradoxical/aetr/core/db/dao/RunDaoManager.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/db/dao/RunDaoManager.scala
@@ -8,7 +8,7 @@ import javax.inject.Inject
 import scala.collection.mutable
 
 class RunDaoManager @Inject()() {
-  def reconstitute(rootId: Root, runData: Seq[RunDao], tree: StepTree): Run = {
+  def reconstitute(rootId: RootId, runData: Seq[RunDao], tree: StepTree): Run = {
     val steps: Map[StepTreeId, StepTree] = new TreeManager(tree).flatten.groupBy(_.id).mapValues(_.head)
 
     val cache = new mutable.HashMap[RunInstanceId, Run]()
@@ -65,7 +65,7 @@ class RunDaoManager @Inject()() {
         result = r.result,
         createdAt = r.createdAt,
         lastUpdatedAt = now,
-        stateUpdatedAt = now
+        stateUpdatedAt = now,
       )
     })
   }

--- a/core/src/main/scala/io/paradoxical/aetr/core/db/dao/RunDaoManager.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/db/dao/RunDaoManager.scala
@@ -65,7 +65,7 @@ class RunDaoManager @Inject()() {
         result = r.result,
         createdAt = r.createdAt,
         lastUpdatedAt = now,
-        stateUpdatedAt = now,
+        stateUpdatedAt = now
       )
     })
   }

--- a/core/src/main/scala/io/paradoxical/aetr/core/db/dao/StepDb.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/db/dao/StepDb.scala
@@ -133,8 +133,12 @@ class StepDb @Inject()(
     provider.withDB(update).map(updated => updated == 1)
   }
 
-  def findRuns(state: RunState): Future[List[RootId]] = {
-    val pendingRoots = runs.query.filter(r => r.state === state && (r.id === r.root)).result
+  def findUnlockedRuns(state: RunState): Future[List[RootId]] = {
+    val pendingRoots = runs.query.filter(r =>
+      r.state === state &&
+      r.id === r.root &&
+      (r.actionLockedTill.isEmpty || r.actionLockedTill <= Instant.now(clock))
+    ).result
 
     provider.withDB(pendingRoots).map(roots => {
       roots.map(r => RootId(r.id.value)).toList

--- a/core/src/main/scala/io/paradoxical/aetr/core/db/dao/StepDb.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/db/dao/StepDb.scala
@@ -4,13 +4,14 @@ import io.paradoxical.aetr.core.config.ServiceConfig
 import io.paradoxical.aetr.core.db.dao.tables._
 import io.paradoxical.aetr.core.model._
 import io.paradoxical.rdb.slick.providers.SlickDBProvider
-import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant}
 import java.util.UUID
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class StepDb @Inject()(
+  clock: Clock,
   provider: SlickDBProvider,
   dataMappers: DataMappers,
   config: ServiceConfig,
@@ -120,7 +121,7 @@ class StepDb @Inject()(
     state: RunState,
     result: Option[ResultData]
   ): Future[Boolean] = {
-    val now = Instant.now()
+    val now = Instant.now(clock)
 
     val update = runs.updateWhere(
       r => r.id === id && r.version === version,
@@ -149,7 +150,7 @@ class StepDb @Inject()(
    * @return
    */
   def lock[T](rootId: RootId)(block: Run => T): Future[Option[T]] = {
-    val now = Instant.now()
+    val now = Instant.now(clock)
 
     val newLockId = LockId(UUID.randomUUID())
 

--- a/core/src/main/scala/io/paradoxical/aetr/core/db/dao/StepDb.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/db/dao/StepDb.scala
@@ -1,15 +1,19 @@
 package io.paradoxical.aetr.core.db.dao
 
+import io.paradoxical.aetr.core.config.ServiceConfig
 import io.paradoxical.aetr.core.db.dao.tables._
 import io.paradoxical.aetr.core.model._
 import io.paradoxical.rdb.slick.providers.SlickDBProvider
 import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class StepDb @Inject()(
   provider: SlickDBProvider,
   dataMappers: DataMappers,
+  config: ServiceConfig,
   steps: Steps,
   runs: Runs,
   children: StepChildren,
@@ -20,7 +24,7 @@ class StepDb @Inject()(
   import dataMappers._
   import provider.driver.api._
 
-  def getTree(stepTreeId: StepTreeId): Future[StepTree] = {
+  def getStep(stepTreeId: StepTreeId): Future[StepTree] = {
     val idQuery = sql"""
                      WITH RECURSIVE getChild(kids) AS (
                        SELECT ${stepTreeId}
@@ -43,6 +47,21 @@ class StepDb @Inject()(
         val allSteps = composer.reconstitute(nodes, children)
 
         allSteps.find(_.id == stepTreeId).get
+    }
+  }
+
+  def deleteStep(stepTree: StepTree): Future[Unit] = {
+    val decomposer = new StepTreeDecomposer(stepTree)
+
+    val deleteExistingChildren = children.query.filter(_.id inSet decomposer.dao.map(_.id)).delete
+
+    val deleteTrees = children.query.filter(_.id inSet decomposer.dao.map(_.id)).delete
+
+    provider.withDB {
+      DBIO.seq(
+        deleteExistingChildren,
+        deleteTrees
+      ).transactionally
     }
   }
 
@@ -74,17 +93,24 @@ class StepDb @Inject()(
     }.map(_ => {})
   }
 
-  def getRun(rootId: Root): Future[Run] = {
+  def getRun(rootId: RootId): Future[Run] = {
     val relatedToRoot = runs.query.filter(_.root === RunInstanceId(rootId.value)).result
 
-    provider.withDB {
-      relatedToRoot
-    }.flatMap(data => {
-      val root = data.find(_.id.value == rootId.value).get
+    provider.withDB(relatedToRoot).flatMap(resolveRunFromTreeNodes(rootId, _))
+  }
 
-      getTree(root.stepTreeId).map(tree => {
-        runDaoManager.reconstitute(rootId, data, tree)
-      })
+  /**
+   * Given a query to find the related run items for a tree,
+   * execute the query and resolve the final run tree
+   *
+   * @param rootId
+   * @return
+   */
+  private def resolveRunFromTreeNodes(rootId: RootId, data: Seq[RunDao]): Future[Run] = {
+    val root = data.find(_.id.value == rootId.value).get
+
+    getStep(root.stepTreeId).map(tree => {
+      runDaoManager.reconstitute(rootId, data, tree)
     })
   }
 
@@ -105,11 +131,65 @@ class StepDb @Inject()(
     provider.withDB(update).map(updated => updated == 1)
   }
 
-  def getPendingRuns(): Future[List[Run]] = {
-    val pendingRoots = runs.query.filter(r => r.state === RunState.Pending && (r.id === r.root)).result
+  def findRuns(state: RunState): Future[List[RootId]] = {
+    val pendingRoots = runs.query.filter(r => r.state === state && (r.id === r.root)).result
 
-    provider.withDB(pendingRoots).flatMap(roots => {
-      Future.sequence(roots.map(r => getRun(Root(r.id.value)))).map(_.toList)
+    provider.withDB(pendingRoots).map(roots => {
+      roots.map(r => RootId(r.id.value)).toList
+    })
+  }
+
+  /**
+   * Locks all nodes in a tree for update
+   * executes the block, then returns a result
+   *
+   * @param rootId
+   * @param block
+   * @tparam T
+   * @return
+   */
+  def lock[T](rootId: RootId)(block: Run => T): Future[Option[T]] = {
+    val now = Instant.now()
+
+    val newLockId = LockId(UUID.randomUUID())
+
+    val lockExpirationTime = now.plus(config.dbLockTime.toSeconds, ChronoUnit.SECONDS)
+
+    // if nobody's ever locked it,
+    // or the lock is expired (it was set to expire and it is currently later than that)
+    // then acquire a lock
+    val lockQuery = runs.query.
+      filter(r =>
+        r.root === rootId.asRunInstance &&
+        r.actionLockedTill.isEmpty || r.actionLockedTill <= now
+      ).
+      map(r => (r.actionLockedTill, r.lockId)).
+      update((Some(lockExpirationTime), Some(newLockId)))
+
+    // unlock the instance and the lock key is the
+    // time we expected to lock till
+    val unlockQuery = runs.query.
+      filter(r =>
+        r.root === rootId.asRunInstance &&
+        r.lockId === newLockId
+      ).
+      map(r => (r.actionLockedTill, r.lockId)).
+      update((None, None))
+
+    provider.withDB(lockQuery).flatMap(results => {
+      // if the lock was acquired, resolve the tree
+      // and allow someone to do work with it
+      // and attempt a safe unlock
+      if (results > 0) {
+        for {
+          data <- getRun(rootId).map(block).map(Some(_))
+          _ <- provider.withDB(unlockQuery)
+        } yield {
+          data
+        }
+      } else {
+        Future.successful(None)
+      }
     })
   }
 
@@ -117,13 +197,13 @@ class StepDb @Inject()(
     for {
       existing <- runs.query.filter(_.id === dao.id).result.headOption
       next = dao.copy(version = dao.version.inc())
-      result <- if(existing.isDefined) {
+      result <- if (existing.isDefined) {
         runs.query.filter(r => r.id === next.id && r.version === dao.version).update(next)
       } else {
         (runs.query += next) andThen DBIO.successful(1)
       }
     } yield {
-      if(result == 0) {
+      if (result == 0) {
         throw VersionMismatchError()
       }
 

--- a/core/src/main/scala/io/paradoxical/aetr/core/db/dao/tables/RunsTable.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/db/dao/tables/RunsTable.scala
@@ -2,10 +2,14 @@ package io.paradoxical.aetr.core.db.dao.tables
 
 import io.paradoxical.aetr.core.db.dao.DataMappers
 import io.paradoxical.aetr.core.model._
+import io.paradoxical.global.tiny.UuidValue
 import io.paradoxical.rdb.slick.dao.SlickDAO
 import java.time.Instant
+import java.util.UUID
 import javax.inject.Inject
 import slick.jdbc.JdbcProfile
+
+case class LockId(value: UUID) extends UuidValue
 
 case class RunDao(
   id: RunInstanceId,
@@ -17,7 +21,9 @@ case class RunDao(
   result: Option[ResultData],
   createdAt: Instant,
   lastUpdatedAt: Instant,
-  stateUpdatedAt: Instant
+  stateUpdatedAt: Instant,
+  actionLockedTill: Option[Instant] = None,
+  lockId: Option[LockId] = None
 )
 
 class Runs @Inject()()(val driver: JdbcProfile, dataMappers: DataMappers) extends SlickDAO {
@@ -49,6 +55,10 @@ class Runs @Inject()()(val driver: JdbcProfile, dataMappers: DataMappers) extend
 
     def stateUpdatedAt = column[Instant]("state_updated_at")
 
+    def actionLockedTill = column[Option[Instant]]("action_locked_till")
+
+    def lockId = column[Option[LockId]]("lock_id")
+
     override def * =
       (
         id,
@@ -60,7 +70,9 @@ class Runs @Inject()()(val driver: JdbcProfile, dataMappers: DataMappers) extend
         result,
         createdAt,
         lastUpdatedAt,
-        stateUpdatedAt
+        stateUpdatedAt,
+        actionLockedTill,
+        lockId
       ) <> (RunDao.tupled, RunDao.unapply)
   }
 

--- a/core/src/main/scala/io/paradoxical/aetr/core/execution/Advancer.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/execution/Advancer.scala
@@ -4,15 +4,17 @@ import io.paradoxical.aetr.core.db.Storage
 import io.paradoxical.aetr.core.graph.RunManager
 import io.paradoxical.aetr.core.model.{RootId, Run, RunState}
 import javax.inject.Inject
+import scala.util.Random
 
 class Advancer @Inject()(storage: Storage, executionHandler: ExecutionHandler) {
   protected val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
   def advanceAll(): Unit = {
-    val pendingRuns = storage.findRuns(RunState.Pending)
+    // shuffle the runs to minimize contention on who tries to acquire a lock
+    val pendingRuns = Random.shuffle(storage.findUnlockedRuns(RunState.Pending))
 
     pendingRuns.foreach(runId => storage.tryLock(runId)(run => {
-      if(run.state == RunState.Pending) {
+      if (run.state == RunState.Pending) {
         dispatch(run)
       }
     }))

--- a/core/src/main/scala/io/paradoxical/aetr/core/execution/Completor.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/execution/Completor.scala
@@ -40,7 +40,7 @@ class Completor @Inject()(
         case Success(value) =>
           logger.info(s"Upserted root ${root.id}")
 
-          if(manager.state != RunState.Complete) {
+          if(manager.state == RunState.Pending) {
             advancer.advance(root.rootId)
           }
       }

--- a/core/src/main/scala/io/paradoxical/aetr/core/execution/ExecutionHandler.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/execution/ExecutionHandler.scala
@@ -5,7 +5,7 @@ import io.paradoxical.aetr.core.model._
 import java.net.URL
 import javax.inject.Inject
 
-case class RunToken(runId: RunId, rootId: Root)
+case class RunToken(runId: RunId, rootId: RootId)
 
 trait UrlExecutor {
   // POST url?aetr=runToken <data>
@@ -24,12 +24,12 @@ class ExecutionHandler @Inject()(storage: Storage, urlExecutor: UrlExecutor) {
       case ApiExecution(url) =>
         urlExecutor.execute(runToken, url, actionable.previousResult)
       case NoOp() =>
-      // TODO:set this to complete
+        storage.trySetRunState(actionable.run.id, actionable.run.version, RunState.Complete)
     }
 
     // if by the time this line runs its already complete, dont set it to executing
     // if we fail here we will end up retrying the execution
-    storage.trySetRunState(actionable.run.id, RunState.Executing)
+    storage.trySetRunState(actionable.run.id, actionable.run.version, RunState.Executing)
   }
 
   private def createRunToken(run: Run): RunToken = {

--- a/core/src/main/scala/io/paradoxical/aetr/core/graph/TreeManager.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/graph/TreeManager.scala
@@ -5,7 +5,7 @@ import io.paradoxical.aetr.core.model._
 import java.util.UUID
 
 class TreeManager(root: StepTree) {
-  private lazy val rootId = Root(UUID.randomUUID())
+  private lazy val rootId = RootId(UUID.randomUUID())
 
   def flatten: List[StepTree] = {
     def all0(curr: StepTree, acc: List[StepTree]): List[StepTree] = {

--- a/core/src/main/scala/io/paradoxical/aetr/core/model/Run.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/model/Run.scala
@@ -7,7 +7,7 @@ import java.util.UUID
 case class Run(
   id: RunInstanceId,
   var children: Seq[Run],
-  rootId: Root,
+  rootId: RootId,
   repr: StepTree,
   version: Version = Version(1),
   createdAt: Instant = Instant.now(),
@@ -22,7 +22,9 @@ case class Run(
 
 trait RunId extends UuidValue with Product
 
-case class Root(value: UUID) extends RunId
+case class RootId(value: UUID) extends RunId {
+  def asRunInstance = RunInstanceId(value)
+}
 case class RunInstanceId(value: UUID) extends RunId
 
 case class Version(value: Long) extends LongValue {

--- a/core/src/main/scala/io/paradoxical/aetr/core/model/RunState.java
+++ b/core/src/main/scala/io/paradoxical/aetr/core/model/RunState.java
@@ -3,6 +3,6 @@ package io.paradoxical.aetr.core.model;
 public enum RunState {
     Pending,
     Executing,
-    Complete,
-    Error
+    Error,
+    Complete
 }

--- a/core/src/main/scala/io/paradoxical/aetr/core/server/modules/Modules.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/server/modules/Modules.scala
@@ -7,19 +7,29 @@ import io.paradoxical.aetr.core.db.PostgresDbProvider
 import io.paradoxical.finatra.modules.Defaults
 import io.paradoxical.jackson.JacksonSerializer
 import io.paradoxical.rdb.slick.providers.{DataSourceProviders, SlickDBProvider}
+import java.time.Clock
 import javax.inject.Singleton
 import javax.sql.DataSource
 import scala.concurrent.ExecutionContext
 import slick.jdbc.JdbcProfile
 
 object Modules {
-  def apply(config: Option[ServiceConfig] = None)(implicit executionContext: ExecutionContext): List[Module] = {
+  def apply(
+    config: Option[ServiceConfig] = None
+  )(implicit executionContext: ExecutionContext): List[Module] = {
     List(
       new ConfigModule(config),
       new PostgresModule,
+      new ClockModule(),
       new JacksonModule()
     ) ++
     Defaults()
+  }
+}
+
+class ClockModule(clock: Clock = Clock.systemUTC()) extends TwitterModule {
+  protected override def configure(): Unit = {
+    bind[Clock].toInstance(clock)
   }
 }
 

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -40,9 +40,6 @@
   <logger name="slick.jdbc.JdbcModelBuilder"              additivity="false" level="${log.slick.createModel:-info}">
     <appender-ref ref="DB-FILE" />
   </logger>
-  <logger name="slick.relational.ResultConverterCompiler" additivity="false" level="${log.slick.resultConverter:-inherited}">
-    <appender-ref ref="DB-FILE" />
-  </logger>
   <logger name="slick.util.AsyncExecutor"                 additivity="false" level="${log.slick.util.asyncExecutor:-inherited}">
     <appender-ref ref="DB-FILE" />
   </logger>

--- a/core/src/test/scala/io/paradoxical/aetr/PostgresDbTestBase.scala
+++ b/core/src/test/scala/io/paradoxical/aetr/PostgresDbTestBase.scala
@@ -1,11 +1,15 @@
 package io.paradoxical.aetr
 
+import com.twitter.util.CountDownLatch
+import io.paradoxical.aetr.core.db.Storage
 import io.paradoxical.aetr.core.db.dao.{StepDb, VersionMismatchError}
 import io.paradoxical.aetr.core.graph.RunManager
 import io.paradoxical.aetr.core.model._
 import io.paradoxical.aetr.db.PostgresDbTestBase
 import io.paradoxical.common.extensions.Extensions._
 import net.codingwell.scalaguice.InjectorExtensions._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class DbTests extends PostgresDbTestBase {
   "DB" should "insert and update" in withDb { injector =>
@@ -17,7 +21,7 @@ class DbTests extends PostgresDbTestBase {
 
     db.upsertStep(parent).waitForResult()
 
-    db.getTree(parent.id).waitForResult() shouldEqual parent
+    db.getStep(parent.id).waitForResult() shouldEqual parent
   }
 
   it should "rebuild children on change" in withDb { injector =>
@@ -35,7 +39,7 @@ class DbTests extends PostgresDbTestBase {
 
     db.upsertStep(parentWithoutChild1).waitForResult()
 
-    db.getTree(parent.id).waitForResult() shouldEqual parentWithoutChild1
+    db.getStep(parent.id).waitForResult() shouldEqual parentWithoutChild1
   }
 
   it should "work on nested trees" in withDb { injector =>
@@ -55,7 +59,7 @@ class DbTests extends PostgresDbTestBase {
 
     db.upsertStep(root).waitForResult()
 
-    db.getTree(root.id).waitForResult() shouldEqual root
+    db.getStep(root.id).waitForResult() shouldEqual root
 
     // drop a tree
 
@@ -63,7 +67,7 @@ class DbTests extends PostgresDbTestBase {
 
     db.upsertStep(rootMinusSubTree).waitForResult()
 
-    db.getTree(root.id).waitForResult() shouldEqual rootMinusSubTree
+    db.getStep(root.id).waitForResult() shouldEqual rootMinusSubTree
   }
 
   it should "upsert and retrieve runs" in withDb { injector =>
@@ -112,7 +116,7 @@ class DbTests extends PostgresDbTestBase {
     val mgr1 = new RunManager(stepRoot)
     val mgr2 = new RunManager(stepRoot)
 
-    def complete(run: Root): Unit = {
+    def complete(run: RootId): Unit = {
       val m = new RunManager(db.getRun(run).waitForResult())
 
       m.completeAll()
@@ -120,18 +124,24 @@ class DbTests extends PostgresDbTestBase {
       db.upsertRun(m.root).waitForResult()
     }
 
+    def pending(): List[Run] = {
+      val runs = db.findRuns(RunState.Pending).flatMap(r => Future.sequence(r.map(db.getRun)))
+
+      runs.waitForResult()
+    }
+
     db.upsertRun(mgr1.root).waitForResult()
     db.upsertRun(mgr2.root).waitForResult()
 
-    db.getPendingRuns().waitForResult().map(_.id) shouldEqual List(mgr1.root.id, mgr2.root.id)
+    pending().map(_.id) shouldEqual List(mgr1.root.id, mgr2.root.id)
 
     complete(mgr2.root.rootId)
 
-    db.getPendingRuns().waitForResult().map(_.id) shouldEqual List(mgr1.root.id)
+    pending().map(_.id) shouldEqual List(mgr1.root.id)
 
     complete(mgr1.root.rootId)
 
-    db.getPendingRuns().waitForResult().map(_.id) shouldEqual Nil
+    pending().map(_.id) shouldEqual Nil
   }
 
   it should "fail to upsert a run if the version is invalid" in withDb { injector =>
@@ -166,5 +176,67 @@ class DbTests extends PostgresDbTestBase {
 
     // update it back should be ok since versions match
     db.upsertRun(pulled).waitForResult()
+  }
+
+  it should "lock on a row" in withDb { injector =>
+    val leaf1: Action = Action(name = NodeName("leaf1"))
+
+    val db = injector.instance[Storage]
+
+    db.upsertSteps(leaf1)
+
+    val run = new RunManager(leaf1).root
+
+    assert(db.tryUpsertRun(run).isSuccess)
+
+    def lockAndSet(state: RunState)(action: => Unit): Boolean = {
+      db.tryLock(run.rootId)(r => {
+        action
+
+        db.trySetRunState(r.id, r.version, state)
+      }).getOrElse(false)
+    }
+
+    val threadTryAcquire = new CountDownLatch(1)
+
+    val threadRunning = new CountDownLatch(1)
+
+    var threadSet = false
+
+    val threadTriedtoAcquire = new CountDownLatch(1)
+
+    val t = new Thread(() => {
+      threadRunning.countDown()
+
+      threadTryAcquire.await()
+
+      // should not be able to set this
+      threadSet = lockAndSet(RunState.Executing) {}
+
+      threadTriedtoAcquire.countDown()
+    })
+
+    t.start()
+
+    // make sure the thread is booted up
+    threadRunning.await()
+
+    val set = lockAndSet(RunState.Complete) {
+      // allow the thread to try and process
+      threadTryAcquire.countDown()
+
+      // wait for the thread to try and acquire the lock we are currently in
+      threadTriedtoAcquire.await()
+    }
+
+    t.join()
+
+    // only allow one of the items to bet set, either the async thread
+    // or the current one
+    assert(set)
+
+    // the thread tried to acquire a lock but was unable to
+    // since the local thread was in the lock
+    assert(!threadSet)
   }
 }

--- a/core/src/test/scala/io/paradoxical/aetr/db/PostgresDbTestBase.scala
+++ b/core/src/test/scala/io/paradoxical/aetr/db/PostgresDbTestBase.scala
@@ -1,8 +1,8 @@
 package io.paradoxical.aetr.db
 
-import com.google.inject.{Guice, Injector}
+import com.google.inject.{Guice, Injector, Module}
 import io.paradoxical.aetr.TestBase
-import io.paradoxical.aetr.core.config.ConfigLoader
+import io.paradoxical.aetr.core.config.{ConfigLoader, ServiceConfig}
 import io.paradoxical.aetr.core.server.modules.Modules
 import io.paradoxical.rdb.config.RdbCredentials
 import net.codingwell.scalaguice.InjectorExtensions._
@@ -13,19 +13,7 @@ class PostgresDbTestBase extends TestBase {
   val docker = Postgres.docker()
 
   def withDb(test: Injector => Any): Unit = {
-    val db = "test_db_" + Math.abs(Random.nextInt())
-
-    val defaultConfig = ConfigLoader.load()
-
-    docker.createDatabase(db)
-
-    val testConfig = defaultConfig.copy(db = defaultConfig.db.copy(
-      url = docker.url(db),
-      credentials = RdbCredentials(
-        user = docker.user,
-        password = docker.password
-      )
-    ))
+    val testConfig = newDbAndConfig
 
     val injector = Guice.createInjector(Modules(config = Some(testConfig)): _*)
 
@@ -34,7 +22,34 @@ class PostgresDbTestBase extends TestBase {
     test(injector)
   }
 
+  protected def newDbAndConfig: ServiceConfig = {
+    val db = "test_db_" + Math.abs(Random.nextInt())
+
+    val defaultConfig = ConfigLoader.load()
+
+    docker.createDatabase(db)
+
+    defaultConfig.copy(db = defaultConfig.db.copy(
+      url = docker.url(db),
+      credentials = RdbCredentials(
+        user = docker.user,
+        password = docker.password
+      )
+    ))
+  }
+
   override protected def afterAll(): Unit = {
     docker.close()
+  }
+}
+
+
+object TestModules {
+  def apply(config: ServiceConfig) = Modules(config = Some(config))
+
+  implicit class WithModules(modules: List[Module]) {
+    def overlay(overrideModules: Module*): List[Module] = {
+      List(com.google.inject.util.Modules.`override`(modules: _*).`with`(overrideModules: _*))
+    }
   }
 }

--- a/core/src/test/scala/io/paradoxical/aetr/mocks/TickClock.scala
+++ b/core/src/test/scala/io/paradoxical/aetr/mocks/TickClock.scala
@@ -1,0 +1,18 @@
+package io.paradoxical.aetr.mocks
+
+import java.time.{Clock, Instant, ZoneId}
+import scala.concurrent.duration.FiniteDuration
+
+class TickClock extends Clock {
+  private var now = Instant.now()
+
+  def tick(duration: FiniteDuration): Unit = {
+    now = now.plusMillis(duration.toMillis)
+  }
+
+  override def withZone(zone: ZoneId): Clock = ???
+
+  override def getZone: ZoneId = ???
+
+  override def instant(): Instant = now
+}


### PR DESCRIPTION
Addresses #10 

Adding faux locking to a run. It doesnt really lock the row other than setting an optimistic lock. Anyone using the lock API will properly be locked on their action blocks inside the lock.

This is needed to make sure that multiple workers don't schedule a run at the same time.

I played with using `select for update` to actually have a row lock on the rows being accessed, but it proved complicated for 2 reasons

1. We have to make sure all DB queries are on the same connection, since a select for update transaction is connection bound, so making other queries via the connection pool will block.  That means exposing some sort of connection bound state, which I didn't want to do.

2. Long blocking while holding a db connection also holds up a thread in the connection pool, so if we are executing something and it takes 30 seconds to response (like some slow API call) then that db thread is totally unusable. WIth a few of these we could exhaust our connection pool and then reads/UI updates/other things can't happen.

With optimistic locking we at least can continue to reason about the db duration time, since the action doesn't block the db.