### PR TITLE
Adding serializable mappers/reducers

### DIFF
--- a/core/src/main/scala/io/paradoxical/aetr/core/model/Executions.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/model/Executions.scala
@@ -1,0 +1,18 @@
+package io.paradoxical.aetr.core.model
+
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type
+import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+import java.net.URL
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  defaultImpl = classOf[NoOp],
+  property = "type")
+@JsonSubTypes(value = Array(
+  new Type(value = classOf[ApiExecution], name = "api"),
+  new Type(value = classOf[NoOp], name = "no-op")
+))
+sealed trait Execution
+case class ApiExecution(url: URL) extends Execution
+case class NoOp() extends Execution

--- a/core/src/main/scala/io/paradoxical/aetr/core/model/Mappers.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/model/Mappers.scala
@@ -1,17 +1,53 @@
 package io.paradoxical.aetr.core.model
 
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type
+import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+import javax.script.{ScriptContext, ScriptEngineManager, SimpleScriptContext}
+import jdk.nashorn.api.scripting.JSObject
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  defaultImpl = classOf[NoOp],
+  property = "type")
+@JsonSubTypes(value = Array(
+  new Type(value = classOf[Mappers.Identity], name = "no-op"),
+  new Type(value = classOf[Mappers.Nashorn], name = "js")
+))
 sealed trait Mapper {
   def map(in: ResultData): ResultData
 }
 
-object Mapper {
-  val identity: Mapper =
-    new Mapper {
-      override def map(in: ResultData): ResultData = in
-    }
+object Mappers {
+  case class Identity() extends Mapper {
+    override def map(in: ResultData): ResultData = in
+  }
 
-  def fromFunc(f: ResultData => ResultData): Mapper =
-    new Mapper {
-      override def map(in: ResultData): ResultData = f(in)
+  // used for testing only
+  case class Function(f: ResultData => ResultData) extends Mapper {
+    override def map(in: ResultData): ResultData = f(in)
+  }
+
+  object Nashorn {
+    protected val engine = new ScriptEngineManager().getEngineByName("nashorn")
+  }
+
+  case class Nashorn(js: String) extends Mapper {
+
+    import Nashorn._
+
+    override def map(in: ResultData): ResultData = {
+      val context = new SimpleScriptContext
+
+      context.setBindings(engine.createBindings, ScriptContext.ENGINE_SCOPE)
+
+      engine.eval(js, context)
+
+      val function = context.getAttribute("apply", ScriptContext.ENGINE_SCOPE).asInstanceOf[JSObject]
+
+      val result = function.call(null, in.value).asInstanceOf[String]
+
+      ResultData(result)
     }
+  }
 }

--- a/core/src/main/scala/io/paradoxical/aetr/core/model/Reducers.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/model/Reducers.scala
@@ -1,21 +1,58 @@
 package io.paradoxical.aetr.core.model
 
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type
+import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+import javax.script.{ScriptContext, ScriptEngineManager, SimpleScriptContext}
+import jdk.nashorn.api.scripting.JSObject
+import scala.collection.JavaConverters._
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  defaultImpl = classOf[NoOp],
+  property = "type")
+@JsonSubTypes(value = Array(
+  new Type(value = classOf[Reducers.NoOp], name = "no-op"),
+  new Type(value = classOf[Reducers.Last], name = "last"),
+  new Type(value = classOf[Reducers.Nashorn], name = "js")
+))
 sealed trait Reducer {
   def reduce(ins: Seq[ResultData]): Option[ResultData]
 }
 
-object Reducer {
-  val noop =
-    new Reducer {
-      override def reduce(ins: Seq[ResultData]): Option[ResultData] = None
-    }
+object Reducers {
+  case class NoOp() extends Reducer {
+    override def reduce(ins: Seq[ResultData]): Option[ResultData] = None
+  }
 
-  val last = new Reducer {
+  case class Last() extends Reducer {
     override def reduce(ins: Seq[ResultData]): Option[ResultData] = ins.lastOption
   }
 
-  def fromFunc(f: Seq[ResultData] => Option[ResultData]): Reducer =
-    new Reducer {
-      override def reduce(ins: Seq[ResultData]): Option[ResultData] = f(ins)
+  case class Function(f: Seq[ResultData] => Option[ResultData]) extends Reducer {
+    override def reduce(ins: Seq[ResultData]): Option[ResultData] = f(ins)
+  }
+
+  object Nashorn {
+    protected val engine = new ScriptEngineManager().getEngineByName("nashorn")
+  }
+
+  case class Nashorn(js: String) extends Reducer {
+
+    import Nashorn._
+
+    override def reduce(ins: Seq[ResultData]): Option[ResultData] = {
+      val context = new SimpleScriptContext
+
+      context.setBindings(engine.createBindings, ScriptContext.ENGINE_SCOPE)
+
+      engine.eval(js, context)
+
+      val function = context.getAttribute("apply", ScriptContext.ENGINE_SCOPE).asInstanceOf[JSObject]
+
+      val result = function.call(null, ins.map(_.value).asJavaCollection.toArray()).asInstanceOf[String]
+
+      Option(result).map(ResultData)
     }
+  }
 }

--- a/core/src/main/scala/io/paradoxical/aetr/core/model/StepTree.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/model/StepTree.scala
@@ -1,9 +1,6 @@
 package io.paradoxical.aetr.core.model
 
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type
-import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 import io.paradoxical.global.tiny.{StringValue, UuidValue}
-import java.net.URL
 import java.util.UUID
 
 sealed trait StepTree {
@@ -40,8 +37,8 @@ case class ParallelParent(
   name: NodeName,
   children: List[StepTree] = Nil,
   root: Option[StepTreeId] = None,
-  reducer: Reducer = Reducer.last,
-  mapper: Mapper = Mapper.identity // Applied to the final, reduced result
+  reducer: Reducer = Reducers.Last(),
+  mapper: Mapper = Mappers.Identity()
 ) extends Parent with MapsResult {
   override def addTree(stepTree: StepTree): Parent = {
     copy(children = children :+ stepTree)
@@ -53,7 +50,7 @@ case class Action(
   name: NodeName,
   root: Option[StepTreeId] = None,
   execution: Execution = NoOp(),
-  mapper: Mapper = Mapper.identity
+  mapper: Mapper = Mappers.Identity()
 ) extends StepTree with MapsResult
 
 object StepTreeId {
@@ -61,19 +58,6 @@ object StepTreeId {
 }
 
 case class StepTreeId(value: UUID) extends UuidValue
-
-@JsonTypeInfo(
-  use = JsonTypeInfo.Id.NAME,
-  include = JsonTypeInfo.As.PROPERTY,
-  defaultImpl = classOf[NoOp],
-  property = "type")
-@JsonSubTypes(value = Array(
-  new Type(value = classOf[ApiExecution], name = "api"),
-  new Type(value = classOf[NoOp], name = "no-op")
-))
-sealed trait Execution
-case class ApiExecution(url: URL) extends Execution
-case class NoOp() extends Execution
 
 case class NodeName(value: String) extends StringValue
 

--- a/core/src/test/scala/io/paradoxical/aetr/DbTests.scala
+++ b/core/src/test/scala/io/paradoxical/aetr/DbTests.scala
@@ -30,6 +30,16 @@ class DbTests extends PostgresDbTestBase {
     db.getStep(parent.id).waitForResult() shouldEqual parent
   }
 
+  it should "save mappers and reducers" in withDb { injector =>
+    val db = injector.instance[StepDb]
+
+    val parent = ParallelParent(name = NodeName("leaf1"), mapper = Mappers.Identity(), reducer = Reducers.Last())
+
+    db.upsertStep(parent).waitForResult()
+
+    db.getStep(parent.id).waitForResult() shouldEqual parent
+  }
+
   it should "rebuild children on change" in withDb { injector =>
     val db = injector.instance[StepDb]
 

--- a/core/src/test/scala/io/paradoxical/aetr/NashornTests.scala
+++ b/core/src/test/scala/io/paradoxical/aetr/NashornTests.scala
@@ -1,0 +1,50 @@
+package io.paradoxical.aetr
+
+import io.paradoxical.aetr.core.model.{Mappers, Reducers, ResultData}
+
+class NashornTests extends TestBase {
+  "Nashorn mapper" should "invoke" in {
+    Mappers.Nashorn(
+      """
+        |function apply(data) {
+        |   return data + "foo";
+        |}
+      """.stripMargin).map(ResultData("bar")) shouldEqual ResultData("barfoo")
+  }
+
+  it should "access object data if its structured" in {
+    val js =   """
+                 |function apply(data) {
+                 |   var parsed = JSON.parse(data);
+                 |
+                 |   parsed.name = parsed.name + "foo";
+                 |
+                 |   return JSON.stringify(parsed);
+                 |}
+               """.stripMargin
+
+    Mappers.Nashorn(js).map(ResultData(
+      """{
+        | "name" : "butts"
+        | }
+      """.stripMargin)).value shouldEqual """{"name":"buttsfoo"}"""
+  }
+
+  "Nashorn reducer" should "reduce" in {
+    Reducers.Nashorn(
+      """
+        |function apply(data) {
+        |   return data[0] + "foo"
+        |}
+      """.stripMargin).reduce(List(ResultData("bar"))) shouldEqual Some(ResultData("barfoo"))
+  }
+
+  it should "return None if null is returned" in {
+    Reducers.Nashorn(
+      """
+        |function apply(data) {
+        |   return null;
+        |}
+      """.stripMargin).reduce(List(ResultData("bar"))) shouldEqual None
+  }
+}

--- a/core/src/test/scala/io/paradoxical/aetr/StepStateTests.scala
+++ b/core/src/test/scala/io/paradoxical/aetr/StepStateTests.scala
@@ -11,7 +11,7 @@ class StepStateTests extends FlatSpec with Matchers with MockitoSugar {
   trait ActionList {
     val rootId = StepTreeId.next
 
-    val action1: Action = Action(id = StepTreeId.next, NodeName("action1"), root = Some(rootId), mapper = Mapper.fromFunc(res => ResultData(res.value + "_mapped")))
+    val action1: Action = Action(id = StepTreeId.next, NodeName("action1"), root = Some(rootId), mapper = Mappers.Function(res => ResultData(res.value + "_mapped")))
     val action2 = Action(id = StepTreeId.next, NodeName("action2"), root = Some(rootId))
     val action3 = Action(id = StepTreeId.next, NodeName("action3"), root = Some(rootId))
 
@@ -21,7 +21,7 @@ class StepStateTests extends FlatSpec with Matchers with MockitoSugar {
       id = StepTreeId.next,
       name = NodeName("parellelParent"),
       root = Some(rootId),
-      reducer = Reducer.fromFunc(s => Some(ResultData(s.map(_.value).mkString(";"))))
+      reducer = Reducers.Function(s => Some(ResultData(s.map(_.value).mkString(";"))))
     ).addTree(action3).addTree(action4)
 
     val sequentialParent = SequentialParent(

--- a/project/BuildConfig.scala
+++ b/project/BuildConfig.scala
@@ -66,6 +66,8 @@ object BuildConfig {
         "-Xfuture"
       ),
 
+      fork in Test := true,
+
       scalacOptions in(Compile, doc) := scalacOptions.value.filterNot(_ == "-Xfatal-warnings"),
       scalacOptions in(Compile, doc) += "-no-java-comments"
     ) ++ Publishing.publishSettings


### PR DESCRIPTION
Building on what @chrisbenincasa started I created json subtypes for both mappers and reducers so we can store these in the DB. I created nashorn based mappers/reducers along with tests so people can inject js from the UI to run as their mappers

Addresses #27 and #15 