### PR TITLE
Storing errors in outputs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ lazy val core = project.settings(commonSettings).settings(
       // relegate back to the previous
       case x @ _ => (assemblyMergeStrategy in assembly).value(x)
     },
+
     libraryDependencies ++= Seq(
       "ch.qos.logback" % "logback-classic" % versions.logback,
       "io.paradoxical" %% "paradox-scala-jackson" % versions.paradox.global,

--- a/core/src/main/resources/ui/src/app/components/run-details/run-details.component.html
+++ b/core/src/main/resources/ui/src/app/components/run-details/run-details.component.html
@@ -1,27 +1,27 @@
 <div class="container-fluid" *ngIf="run">
-  <div class="row">
-    <nav class="col-sm-3 col-md-2 hidden-xs-down bg-light sidebar">
-      <ul class="nav nav-pills flex-column">
-        <li class="nav-item active p-2">
-          <h4>Actions</h4>
-        </li>
-      </ul>
-    </nav>
+    <div class="row">
+        <nav class="col-sm-3 col-md-2 hidden-xs-down bg-light sidebar">
+            <ul class="nav nav-pills flex-column">
+                <li class="nav-item active p-2">
+                    <h4>Actions</h4>
+                </li>
+            </ul>
+        </nav>
 
-    <main class="col-sm-9">
-      <tree-root #tree [nodes]="getNodes()" [options]="getOptions()" (activate)="selectNode($event)">
-        <ng-template #treeNodeTemplate let-node let-index="index">
-          <div>
-            {{node.data.stepTree.name}} - {{node.data.state}}
-          </div>
-        </ng-template>
-      </tree-root>
+        <main class="col-sm-9">
+            <tree-root #tree [nodes]="getNodes()" [options]="getOptions()" (activate)="selectNode($event)">
+                <ng-template #treeNodeTemplate let-node let-index="index">
+                    <div>
+                        {{node.data.stepTree.name}} - {{node.data.state}}
+                    </div>
+                </ng-template>
+            </tree-root>
 
-      <div *ngIf="selectedRunChild && selectedRunChild.state == RunState.Complete">
-        Results:
+            <div *ngIf="selectedRunChild && isComplete(selectedRunChild.state)">
+                Results:
 
-        <pre>{{selectedRunChild.result}}</pre>
-      </div>
-    </main>
-  </div>
+                <pre>{{selectedRunChild.result}}</pre>
+            </div>
+        </main>
+    </div>
 </div>

--- a/core/src/main/resources/ui/src/app/components/run-details/run-details.component.ts
+++ b/core/src/main/resources/ui/src/app/components/run-details/run-details.component.ts
@@ -50,7 +50,7 @@ export class RunDetailsComponent implements OnInit, OnDestroy {
     @ViewChild('tree') tree;
 
     ngAfterViewInit() {
-        if(this.tree) {
+        if (this.tree) {
             this.tree.treeModel.expandAll();
         }
     }
@@ -87,7 +87,7 @@ export class RunDetailsComponent implements OnInit, OnDestroy {
                 forkJoin([run]).subscribe(results => {
                     this.run = results[0];
 
-                    if(this.complete(run.state)) {
+                    if (this.isComplete(run.state)) {
                         this.unwatchTasks();
                     }
                 })
@@ -99,7 +99,7 @@ export class RunDetailsComponent implements OnInit, OnDestroy {
         })
     }
 
-    private complete(state: RunState): boolean {
+    isComplete(state: RunState): boolean {
         return state == this.RunState.Error || state == this.RunState.Complete;
     }
 }

--- a/core/src/main/scala/io/paradoxical/aetr/core/execution/ExecutionHandler.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/execution/ExecutionHandler.scala
@@ -25,17 +25,19 @@ class ExecutionHandler @Inject()(storage: StepsDbSync, urlExecutor: UrlExecutor)
         Success(ExecutionResultState(result = None, RunState.Complete))
     }
 
-    val resultState = result.map(_.state).getOrElse(RunState.Error)
+    val nextState = result.map(_.state).getOrElse(RunState.Error)
+
+    val resultData = result.failed.map(throwable => ResultData(throwable.getMessage)).toOption
 
     try {
-      if (storage.trySetRunState(actionable.run.id, root, resultState)) {
-        logger.info(s"Set run state of $actionable to $resultState")
+      if (storage.trySetRunState(actionable.run.id, root, nextState, result = resultData)) {
+        logger.info(s"Set run state of $actionable to $nextState")
       } else {
         logger.info(s"Runs tate of $actionable was already set!")
       }
     } catch {
       case e: Exception =>
-        logger.error(s"Unable to set run state for $actionable to $resultState")
+        logger.error(s"Unable to set run state for $actionable to $nextState")
 
         throw e
     }

--- a/core/src/main/scala/io/paradoxical/aetr/core/execution/api/UrlExecutorImpl.scala
+++ b/core/src/main/scala/io/paradoxical/aetr/core/execution/api/UrlExecutorImpl.scala
@@ -36,7 +36,15 @@ class UrlExecutorImpl @Inject()(
       val resp = req.execute[String]()
 
       if(resp.isError) {
-        throw new RuntimeException(resp.body)
+        throw new RuntimeException(
+          s"""
+            |{
+            |  "status": "${resp.statusLine}",
+            |  "body": "${resp.body}",
+            |  "code: "${resp.code}"
+            |}
+          """.stripMargin
+        )
       }
 
       logger.trace(s"Got ${resp.code} response for run token = $token} callback url = $url: ${resp.body}")

--- a/core/src/main/scala/io/paradoxical/aetr/core/model/RunState.java
+++ b/core/src/main/scala/io/paradoxical/aetr/core/model/RunState.java
@@ -1,8 +1,19 @@
 package io.paradoxical.aetr.core.model;
 
 public enum RunState {
-    Pending,
-    Executing,
-    Error,
-    Complete
+    Pending(false),
+    Executing(false),
+    Error(true),
+    Complete(true);
+
+    private final boolean isCompleteState;
+
+    RunState(final boolean isCompleteState) {
+
+        this.isCompleteState = isCompleteState;
+    }
+
+    public boolean isCompleteState() {
+        return isCompleteState;
+    }
 }

--- a/core/src/test/scala/io/paradoxical/aetr/StepStateTests.scala
+++ b/core/src/test/scala/io/paradoxical/aetr/StepStateTests.scala
@@ -145,4 +145,19 @@ class StepStateTests extends FlatSpec with Matchers with MockitoSugar {
 
     m.getFinalResult shouldEqual Option(ResultData("p0;p1"))
   }
+
+  it should "propagate errors to the root" in new ActionList {
+    val run = new TreeManager(treeRoot).newRun(input = Some(ResultData("seed")))
+
+    val m = new RunManager(run)
+
+    val actionableAction1 = m.next().head
+
+    val failureData = Some(ResultData("foo"))
+
+    m.setState(actionableAction1.run.id, RunState.Error, Some(failureData))
+
+    assert(m.root.state == RunState.Error)
+    assert(m.root.output == failureData)
+  }
 }


### PR DESCRIPTION
Storing the errors in outputs.  If a child errors out we want that error to be stored and propagated to the root.

![image](https://user-images.githubusercontent.com/1799346/38711987-b426160a-3e7d-11e8-8c50-c73f5cf24587.png)

Addresses #23 
